### PR TITLE
Correct host gdb and openocd build and install paths

### DIFF
--- a/package/cbzone/cbzone.mk
+++ b/package/cbzone/cbzone.mk
@@ -25,4 +25,6 @@ define CBZONE_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/cbzone.{help,motd} $(TARGET_DIR)/var/tmp
 endef
 
+CBZONE_DEPENDENCIES = xlib_libXt
+
 $(eval $(generic-package))

--- a/package/gdb/Config.in.host
+++ b/package/gdb/Config.in.host
@@ -5,7 +5,6 @@ config BR2_PACKAGE_HOST_GDB_ARCH_SUPPORTS
 	depends on !BR2_microblaze
 	depends on !BR2_nios2
 	depends on !BR2_or1k
-	depends on !BR2_riscv
 	depends on !BR2_nds32
 
 comment "Host GDB Options"
@@ -47,6 +46,7 @@ choice
 	prompt "GDB debugger Version"
 	default BR2_GDB_VERSION_8_2
 	depends on !BR2_arc
+	depends on !BR2_riscv
 	depends on !BR2_csky
 	help
 	  Select the version of gdb you wish to use.

--- a/package/gdb/gdb.hash
+++ b/package/gdb/gdb.hash
@@ -8,3 +8,6 @@ sha512  a2b83e949638fa27d3d2b971e3a77902050191d517c5b9ca1273d182b8c3b9da2c993a0d
 
 # Locally calculated (fetched from https://github.com/c-sky/binutils-gdb)
 sha512  c421e1f3c0d6cfb3c04544573c0c4b0075c8d8e3d563c6c234fcc1e4c2167ab203d1e57aec3b58abd348dc46f8cf9b47b753d3a43dba3ea970c9c9a6bd78c07b	gdb-4ecb98fbc2f94dbe01b69384afbc515107de73df.tar.gz
+
+# riscv version
+sha512 5b9bfe9a3c0931ce2f41492e59dbc29c5e957624efc27594d0e99a294fd7f776c00070e14c2ec33c06bddf4fbd417c975816a7b46dd5bb804b1769dc37ebc5cc         gdb-c3eb4078520dad8234ffd7fbf893ac0da23ad3c8.tar.gz

--- a/package/gdb/gdb.mk
+++ b/package/gdb/gdb.mk
@@ -8,6 +8,13 @@ GDB_VERSION = $(call qstrip,$(BR2_GDB_VERSION))
 GDB_SITE = $(BR2_GNU_MIRROR)/gdb
 GDB_SOURCE = gdb-$(GDB_VERSION).tar.xz
 
+ifeq ($(BR2_riscv),y)
+GDB_VERSION=c3eb4078520dad8234ffd7fbf893ac0da23ad3c8
+GDB_SITE = $(call github,riscv,riscv-binutils-gdb,$(GDB_VERSION))/.
+GDB_SOURCE = gdb-$(GDB_VERSION).tar.gz
+GDB_FROM_GIT = y
+endif
+
 ifeq ($(BR2_arc),y)
 GDB_SITE = $(call github,foss-for-synopsys-dwc-arc-processors,binutils-gdb,$(GDB_VERSION))
 GDB_SOURCE = gdb-$(GDB_VERSION).tar.gz

--- a/package/openocd/openocd.mk
+++ b/package/openocd/openocd.mk
@@ -15,12 +15,19 @@ define HOST_OPENOCD_CONFIGURE_CMDS
 	(cd $(@D); \
 	git clone -b 0.76 https://github.com/msteveb/jimtcl; \
 	./bootstrap; \
-	./configure --oldincludedir=$(STAGING_DIR)/usr/include --includedir=$(HOST_DIR)/include --disable-werror \
+	./configure \
+		--oldincludedir=$(STAGING_DIR)/usr/include \
+		--includedir=$(HOST_DIR)/include \
+		--prefix=$(HOST_DIR) \
+		--disable-werror \
 	)
 endef
 
 define HOST_OPENOCD_BUILD_CMDS
-	(cd $(@D); make -j 4 -s)
+	(cd $(@D); \
+	make -j 4 -s LDFLAGS=$(HOST_LDFLAGS); \
+	make install \
+	)
 endef
 
 # Rely on the Config.in options of each individual adapter selecting


### PR DESCRIPTION
cbzone has a libXt dependency. Host GDB was not enabled on riscv. Openocd was not compiled and installed with the correct RPATH.
