### PR TITLE
Force QEMU build to be static

### DIFF
--- a/package/qemu/qemu.mk
+++ b/package/qemu/qemu.mk
@@ -256,7 +256,7 @@ endif
 
 ifeq ($(BR2_PACKAGE_HOST_QEMU_LINUX_USER_MODE),y)
 HOST_QEMU_TARGETS += $(HOST_QEMU_ARCH)-linux-user
-HOST_QEMU_OPTS += --enable-linux-user
+HOST_QEMU_OPTS += --enable-linux-user --static
 
 HOST_QEMU_HOST_SYSTEM_TYPE = $(shell uname -s)
 ifneq ($(HOST_QEMU_HOST_SYSTEM_TYPE),Linux)


### PR DESCRIPTION
QEMU, like most packages, defaults to dynamic executables. But for use within a riscv chroot, a standalone executable is necessary.
